### PR TITLE
chore: deprecate codedeploy.CustomLambdaDeploymentConfig 

### DIFF
--- a/packages/@aws-cdk/aws-codedeploy/lib/lambda/custom-deployment-config.ts
+++ b/packages/@aws-cdk/aws-codedeploy/lib/lambda/custom-deployment-config.ts
@@ -6,26 +6,31 @@ import { ILambdaDeploymentConfig } from './deployment-config';
 
 /**
  * Lambda Deployment config type
+ * @deprecated Use `LambdaDeploymentConfig`
  */
 export enum CustomLambdaDeploymentConfigType {
   /**
    * Canary deployment type
+   * @deprecated Use `LambdaDeploymentConfig`
    */
   CANARY = 'Canary',
 
   /**
    * Linear deployment type
+   * @deprecated Use `LambdaDeploymentConfig`
    */
   LINEAR = 'Linear'
 }
 
 /**
  * Properties of a reference to a CodeDeploy Lambda Deployment Configuration.
+ * @deprecated Use `LambdaDeploymentConfig`
  */
 export interface CustomLambdaDeploymentConfigProps {
 
   /**
    * The type of deployment config, either CANARY or LINEAR
+   * @deprecated Use `LambdaDeploymentConfig`
    */
   readonly type: CustomLambdaDeploymentConfigType;
 
@@ -33,6 +38,7 @@ export interface CustomLambdaDeploymentConfigProps {
    * The integer percentage of traffic to shift:
    * - For LINEAR, the percentage to shift every interval
    * - For CANARY, the percentage to shift until the interval passes, before the full deployment
+   * @deprecated Use `LambdaDeploymentConfig`
    */
   readonly percentage: number;
 
@@ -40,6 +46,7 @@ export interface CustomLambdaDeploymentConfigProps {
    * The interval, in number of minutes:
    * - For LINEAR, how frequently additional traffic is shifted
    * - For CANARY, how long to shift traffic before the full deployment
+   * @deprecated Use `LambdaDeploymentConfig`
    */
   readonly interval: Duration;
 
@@ -47,6 +54,7 @@ export interface CustomLambdaDeploymentConfigProps {
    * The verbatim name of the deployment config. Must be unique per account/region.
    * Other parameters cannot be updated if this name is provided.
    * @default - automatically generated name
+   * @deprecated Use `LambdaDeploymentConfig`
    */
   readonly deploymentConfigName?: string;
 }
@@ -54,18 +62,21 @@ export interface CustomLambdaDeploymentConfigProps {
 /**
  * A custom Deployment Configuration for a Lambda Deployment Group.
  * @resource AWS::CodeDeploy::DeploymentGroup
+ * @deprecated CloudFormation now supports Lambda deployment configurations without custom resources. Use {@link LambdaDeploymentConfig}.
  */
 export class CustomLambdaDeploymentConfig extends Resource implements ILambdaDeploymentConfig {
 
   /**
    * The name of the deployment config
    * @attribute
+   * @deprecated Use `LambdaDeploymentConfig`
    */
   public readonly deploymentConfigName: string;
 
   /**
    * The arn of the deployment config
    * @attribute
+   * @deprecated Use `LambdaDeploymentConfig`
    */
   public readonly deploymentConfigArn: string;
 

--- a/packages/@aws-cdk/aws-codedeploy/test/lambda/custom-deployment-config.test.ts
+++ b/packages/@aws-cdk/aws-codedeploy/test/lambda/custom-deployment-config.test.ts
@@ -1,5 +1,6 @@
 import { Template } from '@aws-cdk/assertions';
 import * as lambda from '@aws-cdk/aws-lambda';
+import { testDeprecated } from '@aws-cdk/cdk-build-tools';
 import * as cdk from '@aws-cdk/core';
 import * as codedeploy from '../../lib';
 
@@ -30,7 +31,7 @@ beforeEach(() => {
 });
 
 
-test('custom resource created', () => {
+testDeprecated('custom resource created', () => {
   // WHEN
   const config = new codedeploy.CustomLambdaDeploymentConfig(stack, 'CustomConfig', {
     type: codedeploy.CustomLambdaDeploymentConfigType.CANARY,
@@ -75,7 +76,7 @@ test('custom resource created', () => {
   });
 });
 
-test('custom resource created with specific name', () => {
+testDeprecated('custom resource created with specific name', () => {
   // WHEN
   const config = new codedeploy.CustomLambdaDeploymentConfig(stack, 'CustomConfig', {
     type: codedeploy.CustomLambdaDeploymentConfigType.CANARY,
@@ -97,7 +98,7 @@ test('custom resource created with specific name', () => {
   });
 });
 
-test('fail with more than 100 characters in name', () => {
+testDeprecated('fail with more than 100 characters in name', () => {
   const app = new cdk.App();
   const stackWithApp = new cdk.Stack(app);
   new codedeploy.CustomLambdaDeploymentConfig(stackWithApp, 'CustomConfig', {
@@ -110,7 +111,7 @@ test('fail with more than 100 characters in name', () => {
   expect(() => app.synth()).toThrow(`Deployment config name: "${'a'.repeat(101)}" can be a max of 100 characters.`);
 });
 
-test('fail with unallowed characters in name', () => {
+testDeprecated('fail with unallowed characters in name', () => {
   const app = new cdk.App();
   const stackWithApp = new cdk.Stack(app);
   new codedeploy.CustomLambdaDeploymentConfig(stackWithApp, 'CustomConfig', {
@@ -123,7 +124,7 @@ test('fail with unallowed characters in name', () => {
   expect(() => app.synth()).toThrow('Deployment config name: "my name" can only contain letters (a-z, A-Z), numbers (0-9), periods (.), underscores (_), + (plus signs), = (equals signs), , (commas), @ (at signs), - (minus signs).');
 });
 
-test('can create linear custom config', () => {
+testDeprecated('can create linear custom config', () => {
   // WHEN
   const config = new codedeploy.CustomLambdaDeploymentConfig(stack, 'CustomConfig', {
     type: codedeploy.CustomLambdaDeploymentConfigType.LINEAR,
@@ -142,7 +143,7 @@ test('can create linear custom config', () => {
   });
 });
 
-test('can create canary custom config', () => {
+testDeprecated('can create canary custom config', () => {
   // WHEN
   const config = new codedeploy.CustomLambdaDeploymentConfig(stack, 'CustomConfig', {
     type: codedeploy.CustomLambdaDeploymentConfigType.CANARY,
@@ -161,7 +162,7 @@ test('can create canary custom config', () => {
   });
 });
 
-test('dependency on the config exists to ensure ordering', () => {
+testDeprecated('dependency on the config exists to ensure ordering', () => {
   // WHEN
   const config = new codedeploy.CustomLambdaDeploymentConfig(stack, 'CustomConfig', {
     type: codedeploy.CustomLambdaDeploymentConfigType.CANARY,

--- a/packages/@aws-cdk/aws-codedeploy/test/lambda/deployment-group.test.ts
+++ b/packages/@aws-cdk/aws-codedeploy/test/lambda/deployment-group.test.ts
@@ -629,3 +629,31 @@ describe('imported with fromLambdaDeploymentGroupAttributes', () => {
     expect(importedGroup.deploymentConfig).toEqual(codedeploy.LambdaDeploymentConfig.CANARY_10PERCENT_5MINUTES);
   });
 });
+
+test('dependency on the config exists to ensure ordering', () => {
+  // WHEN
+  const stack = new cdk.Stack();
+  const application = new codedeploy.LambdaApplication(stack, 'MyApp');
+  const alias = mockAlias(stack);
+  const config = new codedeploy.LambdaDeploymentConfig(stack, 'MyConfig', {
+    trafficRoutingConfig: new codedeploy.TimeBasedCanaryTrafficRoutingConfig({
+      interval: cdk.Duration.minutes(1),
+      percentage: 5,
+    }),
+  });
+  new codedeploy.LambdaDeploymentGroup(stack, 'MyDG', {
+    application,
+    alias,
+    deploymentConfig: config,
+  });
+
+  // THEN
+  Template.fromStack(stack).hasResource('AWS::CodeDeploy::DeploymentGroup', {
+    Properties: {
+      DeploymentConfigName: stack.resolve(config.deploymentConfigName),
+    },
+    DependsOn: [
+      stack.getLogicalId(config.node.defaultChild as codedeploy.CfnDeploymentConfig),
+    ],
+  });
+});


### PR DESCRIPTION
Update tests to use `testDeprecated()`. Also, copied over test  from `custom-deployment-config.test.ts` to `deployment-group.test.ts` to ensure that coverage isn't lost when the deprecated code is removed.

----

### All Submissions:

* [x] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md)


*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
